### PR TITLE
Germline po

### DIFF
--- a/analysis/bcbioSetup_Single_Germline.Rmd
+++ b/analysis/bcbioSetup_Single_Germline.Rmd
@@ -38,7 +38,7 @@ The `googledrive` framework requires authentication with oAuth. This can be done
 
 ```{r project}
 PROJECT <- 'All'
-SECONDARY <- 'run119'
+SECONDARY <- 'po_control'
 
 # Do not change
 TYPE <- 'WGS'
@@ -89,26 +89,34 @@ Find all samples that either are part of the listed project and still need to be
 # Keep rows matching project and type requested; extract path to FASTQ
 # and generate new file name for these
 bcbio <- samples %>%
+  mutate(project_name = if_else(project_owner == '-', 
+                                project_name,
+                                paste(project_owner, project_name, sep='-'))) %>%
   filter(type == TYPE &
            ((project_name == PROJECT & results == '-') | 
            (secondary_analysis == SECONDARY))) %>% 
-  select(illumina_id, fastq, run, project_name, subject_id, sample_id, library_id, 
-         sample_name, assay,
-         phenotype, source, row_id,
-         external_subject_id, external_sample_id, sample_name) %>%
+  select(illumina_id, fastq, run, project_name, 
+         subject_id, sample_id, library_id, 
+         external_subject_id, external_sample_id, sample_name, 
+         assay, phenotype, source, row_id) %>%
+  mutate(subject_id = if_else(subject_id == '-', external_subject_id, subject_id)) %>%
+  mutate(sample_id = if_else(sample_id == '-', external_sample_id, sample_id)) %>%
+  mutate(library_id = if_else(library_id == '-', 'Missing', library_id)) %>%
   mutate(runname = illumina_id) %>%
-  select(-illumina_id)
+  separate(illumina_id, c(NA, 'machine', NA, NA), sep='_')
 
-# Starting with run 108 we switched SampleID and SampleName. For naming conventions 
-# sticking to the old format when deciding what to call the FASTQs. With run 118
-# we introduced internal sample IDs and these should be used going forward
+# Add a 'target' name: what FASTQs are to be called after retrieval from S3
 bcbio <- bcbio %>%
-  mutate(targetname = case_when(run < 108 ~ paste(runname, sample_name, sep = '_'),
-                                run >= 108 & run < 118 ~ paste(runname, sample_id, sep= '_'),
-                                run >= 118 ~ paste(runname, subject_id, sample_id,
-                                                   library_id, sep='_'))) %>%
-  mutate(targetname = str_replace_all(targetname, '-', '_'))
+  mutate(targetname = paste(runname, subject_id, sample_id, library_id, sep='_')) %>%
+  mutate(targetname = str_replace_all(targetname, '-', '_')) 
 
+# Adding a sample 'description' column used to name the sample within bcbio.
+# The description is now a tuple of (subject, sample, library) which should ensure topups
+# are handled properly. 
+bcbio <- bcbio %>%
+  mutate(description = paste(subject_id, sample_id, library_id, sep='_')) %>%
+  mutate(description = str_replace(description, '_topup.', '')) %>%
+  mutate(description = str_replace(description, '_topup', '')) 
 ```
 
 
@@ -116,39 +124,11 @@ bcbio <- bcbio %>%
 
 Assigning patient/family identifiers for Peddy, assigning batches based on the subject id. Samples with the exact same name (but from different runs) are expected to be top-ups and will subsequently be merged using `bcbio_prepare_samples.py`. 
 
-**Note:** This has _not_ been tested for topups where samples information has been captured both in the old _and_ new style (pre/post run 108/118). 
+**Note:** This will likely fail for samples where we have multiple normals that are _not_ top-ups. Might have to handle these cases manually or pick one representative normal.
 
 ```{r assignBatches}
-# Handle cases where a normal matches more than one tumor sample.
-# Courtesy of [Peter Diakumis](https://github.com/pdiakumis)
-get_new_batch <- function(batch, phenotype) {
-  stopifnot(length(batch) == length(phenotype))
-  n <- length(batch)
-
-  new_batch <- vector(mode = "character", length = n)
-  x <- table(phenotype)
-
-  if (n > 2) {
-    tum_ns <- seq_len(x["tumor"])
-    new_batch[phenotype == "tumor"] <- paste0(batch[phenotype == "tumor"], '_', tum_ns)
-    # assume only one normal for now
-    new_batch[phenotype == "normal"] <- paste0(batch[phenotype == "tumor"], '_', tum_ns, collapse = ";")
-  } else {
-    new_batch <- batch
-  }
-  return(new_batch)
-}
-
-# Generating the bcbio YAML template. Again, after run 107 use the SampleName instead
-# of SampleID to label things. Keep the required columns and add information for peddy
-#
-# Remove top-up samples (samples with the exact same description) before calculating
-# batch assignments. We'll add them back in later. This assumes topups are consistently
-# flagged with a `_topup` suffix
+# Generating the bcbio YAML template. Keep the required columns and add information for peddy
 template <- bcbio %>% 
-  mutate(description = case_when(run < 108 ~ sample_name,
-                               run >= 108 ~ sample_id)) %>%
-  mutate(description = str_replace(description, '_topup', '')) %>%
   mutate(family_id = subject_id) %>%
   mutate(individual_id = subject_id) %>%
   select(samplename = targetname,
@@ -160,52 +140,6 @@ template <- bcbio %>%
          external_sample_id,
          external_sample_name = sample_name,
          project_name)
-
-# Only keep one sample row for samples that _do_ have topups
-unique_samples <- template %>%
-  select(-row_id) %>%
-  group_by(description) %>%
-  filter(row_number(description) == 1)
-
-# Identify batches for which we have both tumor and tumor samples
-# Well. Technically just testing that we have two distinct phenotypes.
-# Could be made more specific (e.g., by ensuring that 'normal' is
-# present).
-complete_subjects <- template %>%
-  group_by(individual_id, batch) %>%
-  summarise(phenotype_count = n_distinct(phenotype)) %>%
-  filter(phenotype_count >= 2) %>%
-  select(individual_id)
-
-complete_subjects <- as.vector(complete_subjects$individual_id)
-
-# Create batch information
-batches <- unique_samples %>%
-  group_by(batch) %>%
-  mutate(new_batch = get_new_batch(batch, phenotype)) 
-
-# Bring back the batch information to the main template
-template <- template %>%
-  left_join(batches, by = c('description')) %>%
-  select(samplename = samplename.x,
-         description,
-         batch = new_batch,
-         phenotype = phenotype.x,
-         family_id = family_id.x,
-         individual_id = individual_id.x,
-         source = source.x,
-         external_subject_id = external_subject_id.x,
-         external_sample_id = external_sample_id.x,
-         external_sample_name = external_sample_name.x,
-         project_name = project_name.x,
-         row_id) 
-
-# Useful when we need non-paired samples
-# complete_subjects <- unique(as.vector(template$individual_id))
-
-# Only retain samples that fulfill the 'complete batch' requirement
-template <- template %>%
-  filter(individual_id %in% complete_subjects)
 ```
 
 ### 5. Generating bcbio csv templates on a per-subject basis:
@@ -216,6 +150,8 @@ Generate a file with pointers to the sample FASTQs and their preferred new names
 
 ```{r perBatch}
 write_subject <- function(complete, summary) {
+  summary <- template
+  complete <- 'SBJ00027'
   
   # Create a unique project name
   subject_name <- paste0(timestamp, '_', PROJECT, '_', TYPE, '_', complete)
@@ -292,7 +228,7 @@ write_subject <- function(complete, summary) {
               sep = ',')
 }
 
-for (subject in complete_subjects) {
+for (subject in unique(template$batch)) {
   write_subject(subject, template)
 }
 ```

--- a/analysis/bcbioSetup_Single_Germline.Rmd
+++ b/analysis/bcbioSetup_Single_Germline.Rmd
@@ -173,18 +173,26 @@ write_subject <- function(complete, summary) {
   # longer round in the top level run folder, but in
   # ```<Illumina_ID>/<Project>/<SampleName>/<SampleID>_R1_001.fastq.gz```
   read1 <- bcbio_subset %>%
-    mutate(from = case_when(run <= 80 ~ paste0(fastq, '/', sample_id, '_R1_001.fastq.gz'),
-                            run > 80 & run <= 93 ~ paste0(fastq, '/', project_name, '/', sample_name, '/', sample_id, '_R1_001.fastq.gz'),
-                            run > 93 ~ str_replace(fastq, '.fastq.gz', '_R1_001.fastq.gz'))) %>%
+    mutate(from = case_when(run <= 80 & machine == 'A00130' ~ 
+                              paste0(fastq, '/', external_sample_id, '_R1_001.fastq.gz'),
+                            run > 80 & run <= 93 & machine == 'A00130' ~ 
+                              paste0(fastq, '/', project_name, '/', sample_name, '/', 
+                                     external_sample_id, '_R1_001.fastq.gz'),
+                            run > 93 | machine == 'A01052' ~ 
+                              str_replace(fastq, '.fastq.gz', '_R1_001.fastq.gz'))) %>%
     mutate(to = paste0(targetname, '_R1_001.fastq.gz')) %>%
-    select(from, to)
+    select(from, to, row_id)
   
   read2 <- bcbio_subset %>%
-    mutate(from = case_when(run <= 80 ~ paste0(fastq, '/', sample_id, '_R2_001.fastq.gz'),
-                            run > 80 & run <= 93 ~ paste0(fastq, '/', project_name, '/', sample_name, '/', sample_id, '_R2_001.fastq.gz'),
-                            run > 93 ~ str_replace(fastq, '.fastq.gz', '_R2_001.fastq.gz'))) %>%
+    mutate(from = case_when(run <= 80 & machine == 'A00130' ~ 
+                              paste0(fastq, '/', external_sample_id, '_R2_001.fastq.gz'),
+                            run > 80 & run <= 93 & machine == 'A00130' ~ 
+                              paste0(fastq, '/', project_name, '/', sample_name, '/',
+                                     external_sample_id, '_R2_001.fastq.gz'),
+                            run > 93 | machine == 'A01052' ~ 
+                              str_replace(fastq, '.fastq.gz', '_R2_001.fastq.gz'))) %>%
     mutate(to = paste0(targetname, '_R2_001.fastq.gz')) %>%
-    select(from, to)
+    select(from, to, row_id)
   
   link <- rbind(read1, read2)
 
@@ -196,7 +204,7 @@ write_subject <- function(complete, summary) {
   # Write the file list for staging files. First step, `aws cp` 
   write.table(paste('aws --profile spartan_s3_readonly s3 cp', 
                     link$from_path,
-                    '.',
+                    link$row_id,
                     '--recursive --exclude "*" --include',
                     paste('"', link$from_file, '"', sep = '')),
               file = here::here('output', subject_name, 'data', paste0(subject_name, '_files.sh')),
@@ -206,7 +214,7 @@ write_subject <- function(complete, summary) {
 
   # Second step, rename
   write.table(paste('mv', 
-                    link$from_file,
+                    paste(link$row_id, link$from_file, sep='/'),
                     link$to,
                     sep = ' '),
               file = here::here('output', subject_name, 'data', paste0(subject_name, '_files.sh')),

--- a/analysis/bcbioSetup_Single_Germline.Rmd
+++ b/analysis/bcbioSetup_Single_Germline.Rmd
@@ -108,6 +108,7 @@ bcbio <- bcbio %>%
                                 run >= 118 ~ paste(runname, subject_id, sample_id,
                                                    library_id, sep='_'))) %>%
   mutate(targetname = str_replace_all(targetname, '-', '_'))
+
 ```
 
 

--- a/analysis/bcbioSetup_Single_Germline.Rmd
+++ b/analysis/bcbioSetup_Single_Germline.Rmd
@@ -142,7 +142,29 @@ template <- bcbio %>%
          project_name)
 ```
 
-### 5. Generating bcbio csv templates on a per-subject basis:
+### 5. Add control information
+
+Frequently germline-only samples are control cases for which we want to create validaton results. Assign the right benchmark set based on the subject information.
+
+```{r assignControl}
+# Define what validation data to use; all of these are shipped with bcbio so we don't have to prep standards
+validations <- c('giab-NA12878', 'giab-NA24385', 'giab-NA24631')
+names(validations) <- c('NA12878', 'NA24385', 'NA24631')
+
+# Not the most elegant solution. Help appreciated to clean this up
+template <- template %>% 
+  mutate(validate=ifelse(external_subject_id %in% names(validations), 
+                         paste(validations[external_subject_id], 'truth_small_variants.vcf.gz', sep='/'),
+                         '')) %>%
+  mutate(validate_regions=ifelse(external_subject_id %in% names(validations), 
+                         paste(validations[external_subject_id], 'truth_regions.bed', sep='/'),
+                         '')) %>%
+  mutate(validate_batch=ifelse(external_subject_id %in% names(validations), 
+                         external_subject_id,
+                         ''))
+```
+
+### 6. Generating bcbio csv templates on a per-subject basis:
 
 Generate a file with pointers to the sample FASTQs and their preferred new names as well as a sample descriptor (`.csv`) for bcbio to use as part of it's templating approach. The resulting directory structure can be copied to Spartan, e.g.:
 


### PR DESCRIPTION
Code cleanup to support single sample germline config for bcbio. Drops the tumor/normal pairing code, automatically picks the validation sample based on `subject_id` and now supports samples from both Po and Baymax. 